### PR TITLE
Remove the word "simply" from documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ Apart from simply loading the contents of the new page and replacing it in HTML,
 * `is-rendering` - Assigned right before the content is replaced and removed when the whole process of transition of pages is done. (same as above)
 
 ### Example
-While developing the site, simply define the elements that are being animated and need to be replaced. Let's assume we want to fade in/out the main content of the page.
+While developing the site, define the elements that are being animated and need to be replaced. Let's assume we want to fade in/out the main content of the page.
 ```html
 <html>
     <head>
@@ -91,7 +91,7 @@ import Swup from 'swup'
 const swup = new Swup()
 ```
 
-or simply 
+or 
 
 ```javascript
 var swup = new Swup()


### PR DESCRIPTION
I know the intention is to make the process seem straightforward, but using words like "simply" or "just" can have the unintended effect of making the reader feel inadequate.

http://bradfrost.com/blog/post/just/

https://adactio.com/journal/13521

Hope that helps,

Jeremy