### PR TITLE
Add a new 'willReplaceContent' event triggered right before replacing

### DIFF
--- a/src/modules/renderPage.js
+++ b/src/modules/renderPage.js
@@ -8,6 +8,8 @@ module.exports = function (page, popstate) {
         document.documentElement.classList.add('is-rendering')
     }
 
+    this.triggerEvent('willReplaceContent')
+
     // replace blocks
     for (var i = 0; i < page.blocks.length; i++) {
         document.body.querySelector(`[data-swup="${i}"]`).outerHTML = page.blocks[i]


### PR DESCRIPTION
I needed this event to tear down some dynamic behaviour before the previous content is removed from the page.