### PR TITLE
Fix FireFox right click bug

### DIFF
--- a/dist/swup.js
+++ b/dist/swup.js
@@ -526,7 +526,7 @@ var Swup = function () {
         key: 'linkClickHandler',
         value: function linkClickHandler(event) {
             // no control key pressed
-            if (!event.metaKey) {
+            if (!event.metaKey && !ev.which == 3) {
                 this.triggerEvent('clickLink', event);
                 var link = new _Link2.default();
                 event.preventDefault();

--- a/dist/swup.js
+++ b/dist/swup.js
@@ -526,7 +526,7 @@ var Swup = function () {
         key: 'linkClickHandler',
         value: function linkClickHandler(event) {
             // no control key pressed
-            if (!event.metaKey && !ev.which == 3) {
+            if (!event.metaKey || !ev.which == 3) {
                 this.triggerEvent('clickLink', event);
                 var link = new _Link2.default();
                 event.preventDefault();


### PR DESCRIPTION
On Firefox a right click over a link triggers 'clickLink' event. Check if it's a right click to prevent the trigger. Doesn't work with event.which check, maybe with contextmenu event somewhere?