### PR TITLE
Fix missing serverError handler list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,7 @@ export default class Swup {
             pageLoaded: [],
             scrollStart: [],
             scrollDone: [],
+            serverError: [],
             animationInStart: [],
             animationInDone: [],
             pageRetrievedFromCache: [],


### PR DESCRIPTION
If Swup catches a `500` response, it does not fallback to conventional navigation since it errors in a way that is uncatchable from the promise. This is because it errors in `triggerEvent` because `this._handlers.serverError` does not exist.